### PR TITLE
Timeout reduction in talkshow, with new implementation of non_blocking_pop

### DIFF
--- a/js/talkshow.js
+++ b/js/talkshow.js
@@ -3,10 +3,10 @@
 function Talkshow(uri, poll_frequency) {
   
   this.VERSION = '1.1'
-  this.POLL_INCREMENT = 100;
-  this.MAXIMUM_POLL_TIME = 2000;
-  this.MINIMUM_POLL_TIME = poll_frequency || 200;
-  this.JSONP_WINDOW = 60;
+    this.POLL_INCREMENT = 10;
+    this.MAXIMUM_POLL_TIME = 100;
+    this.MINIMUM_POLL_TIME = poll_frequency || 10;
+    this.JSONP_WINDOW = 6000;
   
   this.url = "http://" + uri;
   this.logger;

--- a/lib/talkshow.rb
+++ b/lib/talkshow.rb
@@ -5,6 +5,7 @@ require 'talkshow/server'
 require 'talkshow/timeout'
 require 'talkshow/javascript_error'
 require 'talkshow/queue'
+require 'timeout'
 
 
 #Main class for talking to a talkshow instrumented js application.
@@ -93,7 +94,7 @@ class Talkshow
     end
   end
   
-  def non_blocking_pop(timeout)
+  def unblocked_pop(timeout)
     sleep_time = 0.1
     answer = nil
     catch(:done) do
@@ -106,6 +107,19 @@ class Talkshow
     answer
   end
 
+  def non_blocking_pop(time_out)
+    answer = nil
+
+    begin
+      ::Timeout::timeout(time_out) {
+        answer = @answer_queue.pop(false)
+      }
+    rescue => e
+      # Do Nothing
+    end
+
+    answer
+  end
 
   # listen for an answer for a specific id, with a timeout, and also reconstitute
   # any chunked responses
@@ -120,6 +134,10 @@ class Talkshow
       raise Talkshow::Timeout.new
     end
     
+    if answer[:id] == 0
+      raise Talkshow::Initialize.new
+    end
+
     mismatch_retry = 3
     if answer[:id].to_i != id.to_i && mismatch_retry >= 0
       puts "Talkshow warning: message mismatch (#{answer[:id]} vs #{id})" unless answer[:id].to_i == 0

--- a/lib/talkshow/timeout.rb
+++ b/lib/talkshow/timeout.rb
@@ -1,4 +1,7 @@
 class Talkshow
   class Talkshow::Timeout < StandardError
   end
+
+  class Talkshow::Initialize < StandardError
+  end
 end


### PR DESCRIPTION
- Reduced timeouts for Talkshow (poll_increment, max_poll_time, min_poll_time, jsonp_window)
- Added Talkshow::Initialize error in timeout.rb
- Re-implemented non_blocking_pop using Timeout class. Renamed older method to unblocked_pop
- Handling answer[:id] == 0 within listen_for_answer
